### PR TITLE
Issue 69 - removing a vertex from the graph

### DIFF
--- a/ruruki/entities.py
+++ b/ruruki/entities.py
@@ -522,6 +522,12 @@ class EntitySet(interfaces.IEntitySet):
         else:
             raise KeyError("No such id {0!r} exists.".format(entity.ident))
 
+        # unbind the entity from the Graph
+        entity.graph = None
+
+        # remove the entity from the _all protected reference
+        self._prop_reference[entity.label]["_all"].discard(entity)
+
         collection = self._prop_reference[entity.label]
         for key in entity.properties:
             if key in collection:

--- a/ruruki/graphs.py
+++ b/ruruki/graphs.py
@@ -462,7 +462,8 @@ class Graph(interfaces.IGraph):
         self.edges.remove(edge)
 
     def remove_vertex(self, vertex):
-        if len(vertex.get_both_edges()) > 0:
+        count = len(vertex.get_both_edges())
+        if count > 0:
             raise interfaces.VertexBoundByEdges(
                 "Vertex {0!r} is still bound to another vertex "
                 "by an edge. First remove all the edges on the vertex and "
@@ -721,8 +722,8 @@ class PersistentGraph(Graph):
         super(PersistentGraph, self).add_vertex_constraint(label, key)
         with open(self.vertices_constraints_path, "w") as constraint_fh:
             data = []
-            for label, key in self.get_vertex_constraints():
-                data.append({"label": label, "key": key})
+            for const_label, const_key in self.get_vertex_constraints():
+                data.append({"label": const_label, "key": const_key})
             json.dump(data, constraint_fh, indent=4)
 
     def add_vertex(self, label=None, **kwargs):

--- a/ruruki/test_behave/graph.feature
+++ b/ruruki/test_behave/graph.feature
@@ -51,3 +51,49 @@ Feature: Graph features
       | ident | label  | properties |
       | 0     | label1 | {}         |
       | 1     | label2 | {}         |
+
+  @load
+  Scenario: Removing a vertex from the graph 
+    Given we have a file object with the following dump content
+    """
+        {
+            "constraints": [
+                {
+                    "key": "uid",
+                    "label": "facility"
+                }
+            ],
+            "edges": [],
+            "vertices": [
+                {
+                    "id": 0,
+                    "label": "facility",
+                    "metadata": {
+                        "in_edge_count": 0,
+                        "out_edge_count": 0
+                    },
+                    "properties": {
+                        "name": "Facility 01",
+                        "uid": "FAC_01"
+                    }
+                },
+                {
+                    "id": 1,
+                    "label": "facility",
+                    "metadata": {
+                        "in_edge_count": 0,
+                        "out_edge_count": 0
+                    },
+                    "properties": {
+                        "name": "Facility 02",
+                        "uid": "FAC_02"
+                    }
+                }
+            ]
+        }
+    """
+    When we load the dump into the database
+    And we remove vertex "0"
+    Then we expect the vertex "0" to be removed from the graph vertices entity set
+    And we expect vertex "0" to be unbound
+

--- a/ruruki/test_behave/steps/graphs.py
+++ b/ruruki/test_behave/steps/graphs.py
@@ -42,6 +42,29 @@ def load_graph_dump_into_the_graph_obj(context):
     context.graph.load(context.dump_file)
 
 
+@when(u'we remove vertex "{text}"')
+def remove_vertex_from_graph(context, text):
+    v = context.graph.get_vertex(int(text))
+    context.removed_vertex = v
+    context.graph.remove_vertex(v)
+
+
+@then(
+    u'we expect the vertex "{text}" to be removed from the graph '
+    'vertices entity set'
+)
+def check_vertex_is_not_in_graph_after_removal(context, text):
+    v = context.removed_vertex
+    assert_that(
+        context.graph.get_vertices("facility").sorted()
+    ).does_not_contain(v)
+
+
+@then(u'we expect vertex "{text}" to be unbound')
+def check_removed_vertex_is_nolonger_bound_to_the_graph(context, text):
+    assert_that(context.removed_vertex.is_bound()).is_false()
+
+
 @then(u'we expect to have "{count}" edge')
 def check_edge_count(context, count):
     """


### PR DESCRIPTION
There was a reported issue when removing a vertex from the graph, and iterating over the graph entity set seemed to still report that the vertex was still around and it showed that the vertex was still bound to the graph. I added in a bug fix and all should be working as expected.

```bash
  @load
  Scenario: Removing a vertex from the graph                                       # ruruki/test_behave/graph.feature:56
    Given we have a empty graph object                                             # ruruki/test_behave/steps/graphs.py:11 0.000s
    Given we have a file object with the following dump content                    # ruruki/test_behave/steps/graphs.py:22 0.000s
      """
          {
              "constraints": [
                  {
                      "key": "uid", 
                      "label": "facility"
                  }
              ], 
              "edges": [], 
              "vertices": [
                  {
                      "id": 0, 
                      "label": "facility", 
                      "metadata": {
                          "in_edge_count": 0, 
                          "out_edge_count": 0
                      }, 
                      "properties": {
                          "name": "Facility 01", 
                          "uid": "FAC_01"
                      }
                  }, 
                  {
                      "id": 1, 
                      "label": "facility", 
                      "metadata": {
                          "in_edge_count": 0, 
                          "out_edge_count": 0
                      }, 
                      "properties": {
                          "name": "Facility 02", 
                          "uid": "FAC_02"
                      }
                  }
              ]
          }
      """
    When we load the dump into the database                                        # ruruki/test_behave/steps/graphs.py:34 0.000s
    And we remove vertex "0"                                                       # ruruki/test_behave/steps/graphs.py:45 0.000s
    Then we expect the vertex "0" to be removed from the graph vertices entity set # ruruki/test_behave/steps/graphs.py:52 0.000s
    And we expect vertex "0" to be unbound                                         # ruruki/test_behave/steps/graphs.py:63 0.000s
```