### PR TITLE
Issue 2 - adding a vertex with constraints after removal

### DIFF
--- a/ruruki/graphs.py
+++ b/ruruki/graphs.py
@@ -461,6 +461,10 @@ class Graph(interfaces.IGraph):
         edge.tail.remove_edge(edge)
         self.edges.remove(edge)
 
+        # need to remove the edge from the internal constraints too
+        if (edge.head, edge.label, edge.tail) in self._econstraints:
+            del self._econstraints[(edge.head, edge.label, edge.tail)]
+
     def remove_vertex(self, vertex):
         count = len(vertex.get_both_edges())
         if count > 0:
@@ -470,6 +474,12 @@ class Graph(interfaces.IGraph):
                 "then remove it again.".format(vertex)
             )
         self.vertices.remove(vertex)
+
+        # need to remove the vertex from the internal constraints too
+        if vertex.label in self._vconstraints:
+            for key in self._vconstraints[vertex.label]:
+                if key in vertex.properties:
+                    self._vconstraints[vertex.label][key].discard(vertex)
 
     def close(self):  # pragma: no cover
         # Nothing to do for the close at this stage.

--- a/ruruki/test_behave/graph.feature
+++ b/ruruki/test_behave/graph.feature
@@ -52,7 +52,7 @@ Feature: Graph features
       | 0     | label1 | {}         |
       | 1     | label2 | {}         |
 
-  @load
+  @vertex
   Scenario: Removing a vertex from the graph 
     Given we have a file object with the following dump content
     """
@@ -97,3 +97,105 @@ Feature: Graph features
     Then we expect the vertex "0" to be removed from the graph vertices entity set
     And we expect vertex "0" to be unbound
 
+  @vertex
+  Scenario: Removing a vertex from the graph and add another with the same constraints
+    Given we have a file object with the following dump content
+    """
+        {
+            "constraints": [
+                {
+                    "key": "uid",
+                    "label": "facility"
+                }
+            ],
+            "edges": [],
+            "vertices": [
+                {
+                    "id": 0,
+                    "label": "facility",
+                    "metadata": {
+                        "in_edge_count": 0,
+                        "out_edge_count": 0
+                    },
+                    "properties": {
+                        "name": "Facility 01",
+                        "uid": "FAC_01"
+                    }
+                },
+                {
+                    "id": 1,
+                    "label": "facility",
+                    "metadata": {
+                        "in_edge_count": 0,
+                        "out_edge_count": 0
+                    },
+                    "properties": {
+                        "name": "Facility 02",
+                        "uid": "FAC_02"
+                    }
+                }
+            ]
+        }
+    """
+    When we load the dump into the database
+    And we remove vertex "0"
+    And we add a new vertex with constraint uid "FAC_01"
+    Then we expect the vertex with id "2" to be added with constraint uid "FAC_01"
+    But when we try to add another vertex with uid "FAC_01" it raises a violation error
+
+  @edge
+  Scenario: Removing a edge from the graph and add another with the same constraints
+    Given we have a file object with the following dump content
+    """
+        {
+            "constraints": [
+                {
+                    "key": "uid", 
+                    "label": "facility"
+                }
+            ], 
+            "edges": [
+                {
+                    "head_id": 0, 
+                    "id": 0, 
+                    "label": "knows", 
+                    "metadata": {}, 
+                    "properties": {
+                        "since": "school"
+                    }, 
+                    "tail_id": 1
+                }
+            ], 
+            "vertices": [
+                {
+                    "id": 1, 
+                    "label": "facility", 
+                    "metadata": {
+                        "in_edge_count": 1, 
+                        "out_edge_count": 0
+                    }, 
+                    "properties": {
+                        "name": "Facility 02", 
+                        "uid": "FAC_02"
+                    }
+                }, 
+                {
+                    "id": 0, 
+                    "label": "facility", 
+                    "metadata": {
+                        "in_edge_count": 0, 
+                        "out_edge_count": 1
+                    }, 
+                    "properties": {
+                        "name": "Facility 01", 
+                        "uid": "FAC_01"
+                    }
+                }
+            ]
+        }
+    """
+    When we load the dump into the database
+    And we remove edge "0"-["knows"]->"1" 
+    And we add a new edge "0"-["knows"]->"1" 
+    Then we expect the edge with id "1", "0"-["knows"]->"1" to be added
+    But when we add a another edge "0"-["knows"]->"1"  it raises a violation error

--- a/ruruki/test_behave/steps/graphs.py
+++ b/ruruki/test_behave/steps/graphs.py
@@ -83,8 +83,8 @@ def step_impl(context, text):
     err = None
     try:
         context.graph.add_vertex("facility", uid=text)
-    except Exception as err:
-        err = err
+    except Exception as error:
+        err = error
     assert_that(err.__class__.__name__).is_equal_to("ConstraintViolation")
 
 
@@ -171,13 +171,13 @@ def check_new_edge_is_created(context, ident, head_ident, tail_ident, label):
 
 
 @then(u'when we add a another edge "{head_ident}"-["{label}"]->"{tail_ident}"  it raises a violation error')
-def step_impl(context, head_ident, label, tail_ident):
+def check_edge_violation(context, head_ident, label, tail_ident):
     err = None
     try:
         context.head = context.graph.get_vertex(int(head_ident))
         context.tail = context.graph.get_vertex(int(tail_ident))
         context.new_edge = context.graph.add_edge(context.head, label, context.tail)
-    except Exception as err:
-        err = err
+    except Exception as error:
+        err = error
     assert_that(err.__class__.__name__).is_equal_to("ConstraintViolation")
 

--- a/ruruki/test_behave/steps/graphs.py
+++ b/ruruki/test_behave/steps/graphs.py
@@ -65,6 +65,29 @@ def check_removed_vertex_is_nolonger_bound_to_the_graph(context, text):
     assert_that(context.removed_vertex.is_bound()).is_false()
 
 
+@when(u'we add a new vertex with constraint uid "{text}"')
+def add_new_vertext_with_constraint_of_deleted_vertex(context, text):
+    v = context.graph.add_vertex("facility", uid=text)
+    context.new_vertex = v
+
+
+@then(u'we expect the vertex with id "{ident}" to be added with constraint uid "{text}"')
+def step_impl(context, ident, text):
+    ident = int(ident)
+    assert_that(context.new_vertex.ident).is_equal_to(ident)
+    assert_that(context.new_vertex.properties["uid"]).is_equal_to(text)
+
+
+@then(u'when we try to add another vertex with uid "{text}" it raises a violation error')
+def step_impl(context, text):
+    err = None
+    try:
+        context.graph.add_vertex("facility", uid=text)
+    except Exception as err:
+        err = err
+    assert_that(err.__class__.__name__).is_equal_to("ConstraintViolation")
+
+
 @then(u'we expect to have "{count}" edge')
 def check_edge_count(context, count):
     """
@@ -124,3 +147,37 @@ def check_edge(context):
         assert_that(vertex.ident).is_equal_to(int(row["ident"]))
         assert_that(vertex.label).is_equal_to(row["label"])
         assert_that(vertex.properties).is_equal_to(eval(row["properties"]))
+
+
+@when(u'we remove edge "{head_ident}"-["{label}"]->"{tail_ident}"')
+def remove_edge(context, head_ident, label, tail_ident):
+    e = context.graph.get_edge(0)
+    context.graph.remove_edge(e)
+
+
+@when(u'we add a new edge "{head_ident}"-["{label}"]->"{tail_ident}"')
+def add_new_edge(context, head_ident, label, tail_ident):
+    context.head = context.graph.get_vertex(int(head_ident))
+    context.tail = context.graph.get_vertex(int(tail_ident))
+    context.new_edge = context.graph.add_edge(context.head, label, context.tail)
+
+
+@then(u'we expect the edge with id "{ident}", "{head_ident}"-["{label}"]->"{tail_ident}" to be added')
+def check_new_edge_is_created(context, ident, head_ident, tail_ident, label):
+    assert_that(context.new_edge.ident).is_equal_to(int(ident))
+    assert_that(context.new_edge.label).is_equal_to(label)
+    assert_that(context.new_edge.head.ident).is_equal_to(int(head_ident))
+    assert_that(context.new_edge.tail.ident).is_equal_to(int(tail_ident))
+
+
+@then(u'when we add a another edge "{head_ident}"-["{label}"]->"{tail_ident}"  it raises a violation error')
+def step_impl(context, head_ident, label, tail_ident):
+    err = None
+    try:
+        context.head = context.graph.get_vertex(int(head_ident))
+        context.tail = context.graph.get_vertex(int(tail_ident))
+        context.new_edge = context.graph.add_edge(context.head, label, context.tail)
+    except Exception as err:
+        err = err
+    assert_that(err.__class__.__name__).is_equal_to("ConstraintViolation")
+


### PR DESCRIPTION
There was a issue that once you have added in a vertex with constraints and then removed it and tried to add another vertex with the same constraint, it would raise a violation error. This is because the entities was not removed from from the constraints internal index.

So now we will removed it from the internal constraint index too. This will also fix the `get_or_create_vertex` issue.

*Excuse the output but `behave` seems to be messing it up*

```bash
  @vertex
  Scenario: Removing a vertex from the graph and add another with the same constraints  # ruruki/test_behave/graph.feature:101
    Given we have a empty graph object                                                  # ruruki/test_behave/steps/graphs.py:11 0.000s
    Given we have a file object with the following dump content                         # ruruki/test_behave/steps/graphs.py:22 0.000s
      """
          {
              "constraints": [
                  {
                      "key": "uid",
                      "label": "facility"
                  }
              ],
              "edges": [],
              "vertices": [
                  {
                      "id": 0,
                      "label": "facility",
                      "metadata": {
                          "in_edge_count": 0,
                          "out_edge_count": 0
                      },
                      "properties": {
                          "name": "Facility 01",
                          "uid": "FAC_01"
                      }
                  },
                  {
                      "id": 1,
                      "label": "facility",
                      "metadata": {
                          "in_edge_count": 0,
                          "out_edge_count": 0
                      },
                      "properties": {
                          "name": "Facility 02",
                          "uid": "FAC_02"
                      }
                  }
              ]
          }
      """
    When we load the dump into the database                                             # ruruki/test_behave/steps/graphs.py:34 0.000s
    And we remove vertex "0"                                                            # ruruki/test_behave/steps/graphs.py:45 0.000s
    And we add a new vertex with constraint uid "FAC_01"                                # ruruki/test_behave/steps/graphs.py:68 0.000s
    Then we expect the vertex with id "2" to be added with constraint uid "FAC_01"      # ruruki/test_behave/steps/graphs.py:74 0.000s
    But when we try to add another vertex with uid "FAC_01" it raises a violation error # ruruki/test_behave/steps/graphs.py:81 0.000s

  @edge
  Scenario: Removing a edge from the graph and add another with the same constraints  # ruruki/test_behave/graph.feature:147
    Given we have a empty graph object                                                # ruruki/test_behave/steps/graphs.py:11 0.000s
    Given we have a file object with the following dump content                       # ruruki/test_behave/steps/graphs.py:22
      """
          {
              "constraints": [
                  {
                      "key": "uid", 
                      "label": "facility"
                  }
    Given we have a file object with the following dump content                       # ruruki/test_behave/steps/graphs.py:22 0.000s
      """     "edges": [
          {       {
              "constraints": [": 0, 
                  {   "id": 0, 
                      "key": "uid", s", 
                      "label": "facility"
                  }   "properties": {
              ],          "since": "school"
              "edges": [ 
                  {   "tail_id": 1
                      "head_id": 0, 
                      "id": 0, 
                      "label": "knows", 
                      "metadata": {}, 
                      "properties": {
                          "since": "school"
                      }, tadata": {
                      "tail_id": 1_count": 1, 
                  }       "out_edge_count": 0
              ],      }, 
              "vertices": [erties": {
                  {       "name": "Facility 02", 
                      "id": 1, : "FAC_02"
                      "label": "facility", 
                      "metadata": {
                          "in_edge_count": 1, 
                          "out_edge_count": 0
                      }, bel": "facility", 
                      "properties": {
                          "name": "Facility 02", 
                          "uid": "FAC_02"": 1
                      }, 
                  },  "properties": {
                  {       "name": "Facility 01", 
                      "id": 0, : "FAC_01"
                      "label": "facility", 
                      "metadata": {
                          "in_edge_count": 0, 
                          "out_edge_count": 1
                      }, 
                      "properties": {
                          "name": "Facility 01", 
                          "uid": "FAC_01"
                      }
                  }
              ]
          }
      """
    When we load the dump into the database                                           # ruruki/test_behave/steps/graphs.py:34 0.000s
    And we remove edge "0"-["knows"]->"1"                                             # ruruki/test_behave/steps/graphs.py:152 0.000s
    And we add a new edge "0"-["knows"]->"1"                                          # ruruki/test_behave/steps/graphs.py:158 0.001s
    Then we expect the edge with id "1", "0"-["knows"]->"1" to be added               # ruruki/test_behave/steps/graphs.py:165 0.000s
    But when we add a another edge "0"-["knows"]->"1"  it raises a violation error    # ruruki/test_behave/steps/graphs.py:173 0.000s

```